### PR TITLE
Second attempt at fixing Neovim support

### DIFF
--- a/plugin/interestingwords.vim
+++ b/plugin/interestingwords.vim
@@ -190,6 +190,13 @@ function! s:markRecentlyUsed(n)
   call add(s:recentlyUsed, a:n)
 endfunction
 
+function! s:uiMode()
+  " Stolen from airline's airline#init#gui_mode()
+  return ((has('nvim') && exists('$NVIM_TUI_ENABLE_TRUE_COLOR') && !exists("+termguicolors"))
+     \ || has('gui_running') || (has("termtruecolor") && &guicolors == 1) || (has("termguicolors") && &termguicolors == 1)) ?
+      \ 'gui' : 'cterm'
+endfunction
+
 " initialise highlight colors from list of GUIColors
 " initialise length of s:interestingWord list
 " initialise s:recentlyUsed list
@@ -197,13 +204,8 @@ function! s:buildColors()
   if (s:hasBuiltColors)
     return
   endif
-  if has('gui_running')
-    let ui = 'gui'
-    let wordColors = g:interestingWordsGUIColors
-  else
-    let ui = 'cterm'
-    let wordColors = g:interestingWordsTermColors
-  endif
+  let ui = s:uiMode()
+  let wordColors = (ui == 'gui') ? g:interestingWordsGUIColors : g:interestingWordsTermColors
   if (exists('g:interestingWordsRandomiseColors') && g:interestingWordsRandomiseColors)
     " fisher-yates shuffle
     let i = len(wordColors)-1


### PR DESCRIPTION
Let's try this again :) . The problem with #26 was that I should have checked for a [bunch more stuff in that if statement if I wanted to do it correctly](https://github.com/vim-airline/vim-airline/blob/master/autoload/airline/init.vim#L113-L115), so I have decided instead to just set both gui and term colors in the highlight call. This should also make it a bit more future-proof.

This introduces a slight change in behavior: if the user set `g:interestingWordsGUIColors` of length _n_ and `g:interestingWordsTermColors` of length _m_, with this patch he will end up with _max(n, m)_ groups (replace _n_ or _m_ with 6 if they aren't defined by user). 

I tested this patch with vim, gvim, neovim and neovim-qt in a couple of different terminals and with a few different settings and it seems to work everywhere now. I would really appreciate if @adoyle-h, @teto and anyone else could give it a try as well before merging.