### PR TITLE
Catch `E486` to prevent error after removing silent navigation

### DIFF
--- a/plugin/interestingwords.vim
+++ b/plugin/interestingwords.vim
@@ -121,6 +121,7 @@ function! WordNavigation(direction)
         normal! N
       endif
     catch /E486/
+      echohl WarningMsg | echomsg "E486: Pattern not found: " . @/
     endtry
   endif
 endfunction

--- a/plugin/interestingwords.vim
+++ b/plugin/interestingwords.vim
@@ -114,11 +114,14 @@ function! WordNavigation(direction)
     endif
     call search(pat, searchFlag)
   else
-    if (a:direction)
-      normal! n
-    else
-      normal! N
-    endif
+    try
+      if (a:direction)
+        normal! n
+      else
+        normal! N
+      endif
+    catch /E486/
+    endtry
   endif
 endfunction
 


### PR DESCRIPTION
This follows-on from issue #33, which resulted in commit b425bb4.

Unfortunately, one side-effect of removing `silent!` is that `E486: Pattern not found: <pattern>` is now seen as an error in `WordNavigation`.  Also requires the extra key press to get rid of the error.

Credit for this resolution is:

* https://github.com/tweekmonster/braceless.vim/blob/3928fe18fb7c8561beed6a945622fd985a8e638b/autoload/braceless/python/format.vim#L120-L126

Finally, this isn't perfect, in that the `E486` message is no longer displayed after hitting `n` or `N` -- instead, it shows `search hit BOTTOM, continuing at TOP` (or vice versa).  But the meaning is still correct and this avoids the ugly error.