### PR TITLE
Fix default mappings created regardless of setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ Finally, if you don't want to toggle every single highlighted word and want to c
 The plugin comes with those default mapping, but you can change it as you like:
 
 ```vimscript
+let g:interestingWordsDefaultMappings = 0
+
 nnoremap <silent> <leader>k :call InterestingWords('n')<cr>
 nnoremap <silent> <leader>K :call UncolorAllWords()<cr>
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,11 @@ The plugin comes with those default mapping, but you can change it as you like:
 let g:interestingWordsDefaultMappings = 0
 
 nnoremap <silent> <leader>k :call InterestingWords('n')<cr>
+vnoremap <silent> <leader>k :call InterestingWords('v')<cr>
 nnoremap <silent> <leader>K :call UncolorAllWords()<cr>
 
-nnoremap <silent> n :call WordNavigation('forward')<cr>
-nnoremap <silent> N :call WordNavigation('backward')<cr>
+nnoremap <silent> n :call WordNavigation(1)<cr>
+nnoremap <silent> N :call WordNavigation(0)<cr>
 ```
 
 Thanks to **@gelguy** it is now possible to randomise and configure your own colors

--- a/plugin/interestingwords.vim
+++ b/plugin/interestingwords.vim
@@ -244,16 +244,14 @@ if !exists('g:interestingWordsDefaultMappings')
     let g:interestingWordsDefaultMappings = 1
 endif
 
-if !hasmapto('<Plug>InterestingWords')
+if g:interestingWordsDefaultMappings
     nnoremap <silent> <leader>k :call InterestingWords('n')<cr>
     vnoremap <silent> <leader>k :call InterestingWords('v')<cr>
     nnoremap <silent> <leader>K :call UncolorAllWords()<cr>
 
     nnoremap <silent> n :call WordNavigation(1)<cr>
     nnoremap <silent> N :call WordNavigation(0)<cr>
-endif
 
-if g:interestingWordsDefaultMappings
    try
       nnoremap <silent> <unique> <script> <Plug>InterestingWords
                \ :call InterestingWords('n')<cr>


### PR DESCRIPTION
I noticed both mine and default mappings worked, and turning off the default ones wasn't covered in README, so I took a look at code and noticed `g:interestingWordsDefaultMappings`, and set it to 0, but it didn't fix the issue.

Don't know a thing about vimscript, so I'm not sure if this is ok... but it seems to work.