### PR TITLE
catch errors in WordNavigation when usign nowrapscan

### DIFF
--- a/plugin/interestingwords.vim
+++ b/plugin/interestingwords.vim
@@ -120,8 +120,8 @@ function! WordNavigation(direction)
       else
         normal! N
       endif
-    catch /E486/
-      echohl WarningMsg | echomsg "E486: Pattern not found: " . @/
+    catch /E486\|E384\|E385/
+      echohl WarningMsg | echomsg "Pattern not found: " . @/
     endtry
   endif
 endfunction


### PR DESCRIPTION
When using `set nowrapscan` and matching with `*` or `#` then `n` or `N`, WordNavigation still issues an error message when hitting top (E384) and bottom (E385) of the file.
I included these error codes in the `catch` command.